### PR TITLE
Added ng-bind-html for "error" and "no results" message.

### DIFF
--- a/app/modules/app.js
+++ b/app/modules/app.js
@@ -41,5 +41,5 @@
      *              - contents generated but not yet transcluded
      *
      */
-    angular.module('mdDataTable', ['mdtTemplates', 'ngMaterial', 'ngMdIcons']);
+    angular.module('mdDataTable', ['mdtTemplates', 'ngMaterial', 'ngMdIcons', 'ngSanitize']);
 }());

--- a/app/modules/main/templates/generateRows.html
+++ b/app/modules/main/templates/generateRows.html
@@ -33,12 +33,12 @@
     </td>
 </tr>
 <tr ng-show="mdtPaginationHelper.isLoadError">
-    <td colspan="999">
-        {{mdtPaginationHelper.mdtRowPaginatorErrorMessage}}
+    <td colspan="999" class="errorMessage">
+        <ng-bind-html ng-bind-html="mdtPaginationHelper.mdtRowPaginatorErrorMessage"></ng-bind-html>
     </td>
 </tr>
 <tr ng-show="mdtPaginationHelper.isNoResults && !mdtPaginationHelper.isLoadError">
-    <td colspan="999">
-        {{mdtPaginationHelper.mdtRowPaginatorNoResultsMessage}}
+    <td colspan="999" class="noResultMessage">
+        <ng-bind-html ng-bind-html="mdtPaginationHelper.mdtRowPaginatorNoResultsMessage"></ng-bind-html>
     </td>
 </tr>

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -211,9 +211,4 @@
     .virtualRepeatEnabled .originalHeader md-checkbox{
         display: none;
     }
-
-    .noResultMessage, .errorMessage {
-        text-align: center;
-        font-weight: bold;
-    }
 }

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -211,4 +211,9 @@
     .virtualRepeatEnabled .originalHeader md-checkbox{
         display: none;
     }
+
+    .noResultMessage, .errorMessage {
+        text-align: center;
+        font-weight: bold;
+    }
 }


### PR DESCRIPTION
- **Added ng-bind-html for error and no results message.** 
This allows to have html tags together with plain text for custom error messages and no results messages.

- **Added css class to style error and no results message.**
Further customisation is now possible for those elements by using the respective new css classes (.errorMessage, .noResultMessage).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iamisti/mddatatable/163)
<!-- Reviewable:end -->
