### PR TITLE
move phantom and jshint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-watch": "~4.3.5",
     "jasmine-core": "^2.4.1",
     "jasmine-reporters": "~2.1.0",
+    "jshint": "^2.9.3",
     "karma": "~0.13.15",
     "karma-coverage": "~0.5.3",
     "karma-jasmine": "~0.3.6",
@@ -42,6 +43,7 @@
     "karma-traceur-preprocessor": "~0.4.0",
     "lodash": "~3.10.1",
     "main-bower-files": "~2.11.0",
+    "phantomjs": "^2.1.7",
     "run-sequence": "~1.1.5",
     "traceur": "~0.0.95",
     "wallaby-ng-html2js-preprocessor": "^0.1.0"
@@ -54,8 +56,6 @@
     "angular-material-icons": "~v0.6.0",
     "angular-sanitize": "~1.5.8",
     "jquery": "~2.1.4",
-    "jshint": "^2.9.2",
-    "lodash": "~3.10.1",
-    "phantomjs": "^2.1.7"
+    "lodash": "~3.10.1"
   }
 }


### PR DESCRIPTION
Jshint and phantomjs aren't needed as dependencies, so I have moved them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iamisti/mddatatable/191)
<!-- Reviewable:end -->
