### PR TITLE
When a tooltip isn't desired (setting column-definition to empty stri…

### DIFF
--- a/app/modules/main/templates/mdtGeneratedHeaderCellContent.html
+++ b/app/modules/main/templates/mdtGeneratedHeaderCellContent.html
@@ -22,7 +22,7 @@
     </mdt-checkbox-column-filter>
 
     <div ng-if="headerRowData.columnSort.isEnabled">
-        <md-tooltip ng-show="headerRowData.columnDefinition">{{headerRowData.columnDefinition}}</md-tooltip>
+        <md-tooltip ng-if="headerRowData.columnDefinition">{{headerRowData.columnDefinition}}</md-tooltip>
 
         <mdt-sorting-icons size="16" data="headerRowData" ng-show="headerRowData.alignRule == 'right' && !headerRowData.columnFilter.isEnabled"></mdt-sorting-icons>
 
@@ -31,7 +31,7 @@
         <mdt-sorting-icons size="16" data="headerRowData" ng-show="headerRowData.alignRule == 'left' && !headerRowData.columnFilter.isEnabled"></mdt-sorting-icons>
     </div>
     <div ng-if="!headerRowData.columnSort.isEnabled">
-        <md-tooltip ng-show="headerRowData.columnDefinition">{{headerRowData.columnDefinition}}</md-tooltip>
+        <md-tooltip ng-if="headerRowData.columnDefinition">{{headerRowData.columnDefinition}}</md-tooltip>
 
         <span ng-include src="'/main/templates/cells/generateCellValue.html'" class="no-outline"></span>
     </div>


### PR DESCRIPTION
…ng), there will be console error "Text for the tooltip has not been provided. Please include text within the mdTooltip element.".

This change will fix it by not including tooltip into DOM when there's no text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iamisti/mddatatable/303)
<!-- Reviewable:end -->
