### PR TITLE
Fix the issue that cause that all new columns are hidden after the mdtTable is initialized

### DIFF
--- a/app/modules/main/features/ColumnSelectorFeature/ColumnSelectorFeature.js
+++ b/app/modules/main/features/ColumnSelectorFeature/ColumnSelectorFeature.js
@@ -30,6 +30,7 @@
             }else{
                 cellDataToStore.columnSelectorFeature.isHidden = false;
             }
+			cellDataToStore.columnSelectorFeature.isVisible = !cellDataToStore.columnSelectorFeature.isHidden;
         };
 
         /**


### PR DESCRIPTION
Fix the issue that cause that all columns are hidden when mdtColumn are generated dynamically by ngRepeat after the mdtTable is initialized, assigning default value for ‘columnSelectorFeature.isVisible’

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iamisti/mddatatable/339)
<!-- Reviewable:end -->
