### PR TITLE
Update JQUERY 2.1.4 because XSS security bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "angular-material": "1.1.1",
     "angular-material-icons": "~v0.6.0",
     "angular-sanitize": "~1.5.8",
-    "jquery": "~2.1.4",
+    "jquery": "~3.3.1",
     "lodash": "~3.10.1"
   }
 }


### PR DESCRIPTION
The **JQUERY 2.1.4** has **reported** as **insecure** on [NSP-328](https://nodesecurity.io/advisories/328). 

Updated to the **latest** 3.X.X (**3.3.1**) version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iamisti/mddatatable/341)
<!-- Reviewable:end -->
